### PR TITLE
Genericize "PA" to "organization" in 0215.md

### DIFF
--- a/aip/general/0215.md
+++ b/aip/general/0215.md
@@ -57,7 +57,7 @@ Common protos shall always have a package structure ending in `type` (e.g.
 `google.type`, `google.cloud.type`).
 
 **Warning:** This is a relatively rare occurrence. If you find yourself adding
-protos to your PA's `type` directory frequently, double-check that this is
+protos to your organizations's `type` package frequently, double-check that this is
 actually where they belong.
 
 For more information on common protos, consult [AIP-213][].


### PR DESCRIPTION
Removing "PA" terminology from a warning, and replacing it with generic "organization" terminology.